### PR TITLE
feat: added key-value storage, improved random port selection, UI improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "release": "scripts/release.sh"
   },
   "dependencies": {
+    "bson": "4.6.5",
     "express": "4.18.0",
-    "get-port": "6.1.2",
     "ink": "3.2.0",
     "ink-text-input": "4.0.3",
+    "is-port-reachable": "4.0.0",
     "meow": "10.1.2",
     "react": "18.0.0"
   },

--- a/src/App/Start/Start.tsx
+++ b/src/App/Start/Start.tsx
@@ -46,7 +46,7 @@ export function Start() {
       gameType === "path"
         ? path.relative(".", gamePathOrUrl) === ""
           ? "Current directory"
-          : `\`${path.resolve(gamePathOrUrl)}\``
+          : `${path.resolve(gamePathOrUrl)}`
         : gamePathOrUrl,
     [gamePathOrUrl, gameType]
   )
@@ -77,11 +77,14 @@ export function Start() {
         paddingX={4}
         paddingY={1}
         borderStyle="round"
-        borderColor={gamePathOrUrlValid ? "green" : "red"}
+        borderColor="green"
         flexDirection="column"
       >
-        <Text color="green">App is available at {appUrls.join(", ")}</Text>
-        <Text color="green">Game: {fullGamePathOrUrl}</Text>
+        <Text color="green">App:</Text>
+        <Text> Local: {appUrls.localhost}</Text>
+        {appUrls.ip && <Text> On your network: {appUrls.ip}</Text>}
+        <Text color="green">Game:</Text>
+        <Text> {fullGamePathOrUrl}</Text>
         <Box height={1} />
         <Box>
           <ExitKey />

--- a/src/App/Start/useGameServer.tsx
+++ b/src/App/Start/useGameServer.tsx
@@ -1,7 +1,11 @@
 import express from "express"
-import getPort from "get-port"
+import http from "http"
 import path from "path"
 import { useState, useEffect } from "react"
+
+import { choosePort } from "../../lib/choosePort.js"
+import { getServerPort } from "../../lib/getServerPort.js"
+import { storage } from "../../lib/storage/storage.js"
 
 export function useGameServer({ gamePath }: { gamePath?: string }) {
   const [port, setPort] = useState<number | null>(null)
@@ -9,14 +13,19 @@ export function useGameServer({ gamePath }: { gamePath?: string }) {
   useEffect(() => {
     if (!gamePath || port) return
 
-    getPort({ port: 3001 }).then((freePort) => {
+    choosePort([3001, storage.get("lastGameServerPort")]).then((portToUse) => {
       const gameServer = express()
 
       gameServer.use("/", express.static(path.resolve(gamePath)))
 
-      gameServer.listen(freePort, () => setPort(freePort))
+      const server = http.createServer(gameServer)
+      server.listen(portToUse, () => setPort(getServerPort(server)))
     })
   }, [gamePath, port])
+
+  useEffect(() => {
+    if (port) storage.set("lastGameServerPort", port)
+  }, [port])
 
   return port ? { port } : null
 }

--- a/src/App/Start/useLocalUrls.tsx
+++ b/src/App/Start/useLocalUrls.tsx
@@ -3,11 +3,19 @@ import { detectLocalIP } from "../../lib/detectLocalIP.js"
 const localIp = detectLocalIP()
 
 export function useLocalUrls(port?: number) {
-  if (!port) return []
+  const urls: {
+    localhost: string | null
+    ip: string | null
+  } = {
+    localhost: null,
+    ip: null,
+  }
 
-  const urls = [`http://localhost:${port}`]
+  if (!port) return urls
 
-  if (localIp) urls.push(`http://${localIp}:${port}`)
+  urls.localhost = `http://localhost:${port}`
+
+  if (localIp) urls.ip = `http://${localIp}:${port}`
 
   return urls
 }

--- a/src/lib/choosePort.tsx
+++ b/src/lib/choosePort.tsx
@@ -1,0 +1,16 @@
+import isPortReachable from "is-port-reachable"
+
+const RANDOM_PORT = 0
+
+export async function choosePort(portsToTry: (number | undefined)[]) {
+  for (const port of portsToTry) {
+    if (
+      typeof port === "number" &&
+      !(await isPortReachable(port, { host: "localhost" }))
+    ) {
+      return port
+    }
+  }
+
+  return RANDOM_PORT
+}

--- a/src/lib/getServerPort.tsx
+++ b/src/lib/getServerPort.tsx
@@ -1,0 +1,11 @@
+import { Server } from "net"
+
+export function getServerPort(server: Server) {
+  const address = server.address()
+
+  if (!address || typeof address === "string") {
+    throw new Error("Unexpected server address response")
+  }
+
+  return address.port
+}

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -1,0 +1,29 @@
+import { serialize, deserialize } from "bson"
+import fs from "fs"
+import os from "os"
+import path from "path"
+
+import { Storage } from "./types.js"
+
+const dataDir = path.resolve(os.tmpdir(), "rune")
+fs.mkdirSync(dataDir, { recursive: true })
+
+export const storage = {
+  get<T extends keyof Storage>(key: T) {
+    try {
+      return deserialize(fs.readFileSync(valueFile(key))).value as Storage[T]
+    } catch (e) {
+      return undefined
+    }
+  },
+  set<T extends keyof Storage>(key: T, value: Storage[T]) {
+    fs.writeFileSync(valueFile(key), serialize({ value }))
+  },
+  delete(key: keyof Storage) {
+    fs.writeFileSync(valueFile(key), "")
+  },
+}
+
+function valueFile(key: keyof Storage) {
+  return path.resolve(dataDir, `${key}.value`)
+}

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -1,0 +1,15 @@
+import { Binary } from "bson"
+
+export interface Storage extends StorageObject {
+  lastAppServerPort: number
+  lastGameServerPort: number
+}
+
+export interface StorageObject {
+  [key: string]: StorageValue<string | number | boolean | null | Date | Binary>
+}
+
+type StorageValue<T> =
+  | T
+  | StorageValue<T>[]
+  | { [key: string]: StorageValue<T> }

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,6 +446,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 body-parser@1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
@@ -478,6 +483,21 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+bson@4.6.5:
+  version "4.6.5"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-4.6.5.tgz#1a410148c20eef4e40d484878a037a7036e840fb"
+  integrity sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==
+  dependencies:
+    buffer "^5.6.0"
+
+buffer@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -1233,11 +1253,6 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-get-port@6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
-  integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
-
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
@@ -1369,6 +1384,11 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -1556,6 +1576,11 @@ is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-port-reachable@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-port-reachable/-/is-port-reachable-4.0.0.tgz#dac044091ef15319c8ab2f34604d8794181f8c2d"
+  integrity sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==
 
 is-regex@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
Free port selection should now work more reliably.

The last used random free port is saved to avoid getting a random port every time if preferred ports are unavailable.

Some minor UI changes:
```
╭─────────────────────────────────────────────────────────────────────╮
│                                                                     │
│    App:                                                             │
│     Local: http://localhost:3000                                    │
│     On your network: http://192.168.50.252:3000                     │
│    Game:                                                            │
│     /my/game/path                                                   │
│                                                                     │
│    Press `q` to exit                             Rune CLI v1.1.0    │
│                                                                     │
╰─────────────────────────────────────────────────────────────────────╯
```