### PR TITLE
Update README.md about local mobile running

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ challenge number.
 
 <img src="https://user-images.githubusercontent.com/7106681/166223264-81029004-c985-49e6-b486-1d134686354e.png" height="500" /> <img src="https://user-images.githubusercontent.com/7106681/166223386-1d04ba1d-bde7-40c8-a94b-b4d12b13249b.png" height="500" />
 
+Note that you must have TCP ports 3000 and 3001 open on your system's firewall,
+if you have a firewall enabled, to enable running the game from a mobile device
+on your local network.
+
 ### Upload your game
 
 ```sh


### PR DESCRIPTION
I had problems running my game from a mobile device on the same network, and the problem was fixed by opening TCP ports 3000 and 3001 on my system's firewall. This commit notes that these ports should be open if one wants to run their game from a mobile device on the same network.

If the notice text should be moved elsewhere, please let me know.